### PR TITLE
Align Terraform  config with current state

### DIFF
--- a/terraform/envs/dev/main.tf
+++ b/terraform/envs/dev/main.tf
@@ -66,6 +66,11 @@ module "upload-service" {
 
   // Slack
   slack_webhook = "${var.slack_webhook}"
+
+  // AWS RDS Cluster Instance
+  aws_rds_cluster_instance_class="${var.aws_rds_cluster_instance_class}"
+  aws_rds_cluster_instance_engine_version="${var.aws_rds_cluster_instance_engine_version}"
+  aws_rds_db_cluster_parameter_group_name="${var.aws_rds_db_cluster_parameter_group_name}"
 }
 
 output "upload_csum_lambda_role_arn" {

--- a/terraform/envs/dev/variables.tf
+++ b/terraform/envs/dev/variables.tf
@@ -109,3 +109,18 @@ variable "dcp_auth0_audience" {
 variable "gcp_service_acct_creds" {
   type = "string"
 }
+
+// AWS RDS Cluster instance
+
+variable "aws_rds_cluster_instance_class" {
+  type = "string"
+}
+
+variable "aws_rds_cluster_instance_engine_version" {
+  type = "string"
+}
+
+variable "aws_rds_db_cluster_parameter_group_name" {
+  type = "string"
+}
+

--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -66,6 +66,11 @@ module "upload-service" {
 
   // Slack
   slack_webhook = "${var.slack_webhook}"
+
+  // AWS RDS Cluster Instance
+  aws_rds_cluster_instance_class="${var.aws_rds_cluster_instance_class}"
+  aws_rds_cluster_instance_engine_version="${var.aws_rds_cluster_instance_engine_version}"
+  aws_rds_db_cluster_parameter_group_name="${var.aws_rds_db_cluster_parameter_group_name}"
 }
 
 output "upload_csum_lambda_role_arn" {

--- a/terraform/envs/staging/main.tf
+++ b/terraform/envs/staging/main.tf
@@ -66,6 +66,11 @@ module "upload-service" {
 
   // Slack
   slack_webhook = "${var.slack_webhook}"
+
+  // AWS RDS Cluster Instance
+  aws_rds_cluster_instance_class="${var.aws_rds_cluster_instance_class}"
+  aws_rds_cluster_instance_engine_version="${var.aws_rds_cluster_instance_engine_version}"
+  aws_rds_db_cluster_parameter_group_name="${var.aws_rds_db_cluster_parameter_group_name}"
 }
 
 output "upload_csum_lambda_role_arn" {

--- a/terraform/modules/database/database.tf
+++ b/terraform/modules/database/database.tf
@@ -2,10 +2,10 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   count              = "${var.db_instance_count}"
   identifier         = "upload-cluster-${var.deployment_stage}-${count.index}"
   cluster_identifier = "${aws_rds_cluster.upload.id}"
-  instance_class     = "db.t3.medium"
+  instance_class     = "${var.aws_rds_cluster_instance_class}"
   publicly_accessible = "true"
   engine                  = "aurora-postgresql"
-  engine_version          = "10.11"
+  engine_version          = "${var.aws_rds_cluster_instance_engine_version}"
   auto_minor_version_upgrade = "true"
   performance_insights_enabled = "true"
   preferred_maintenance_window = "${var.preferred_maintenance_window}"
@@ -15,7 +15,7 @@ resource "aws_rds_cluster" "upload" {
   apply_immediately       = "false"
   cluster_identifier      = "upload-${var.deployment_stage}"
   engine                  = "aurora-postgresql"
-  engine_version          = "10.11"
+  engine_version          = "${var.aws_rds_cluster_instance_engine_version}"
   availability_zones      = ["us-east-1a", "us-east-1c", "us-east-1d"]
   database_name           = "upload_${var.deployment_stage}"
   master_username         = "${var.db_username}"
@@ -28,7 +28,7 @@ resource "aws_rds_cluster" "upload" {
   skip_final_snapshot     = "true"
   vpc_security_group_ids  = ["${aws_security_group.rds-postgres.id}"]
   db_subnet_group_name    = "${aws_db_subnet_group.db_subnet_group.name}"
-  db_cluster_parameter_group_name = "default.aurora-postgresql10"
+  db_cluster_parameter_group_name = "${var.aws_rds_db_cluster_parameter_group_name}"
   tags          = {
     Name        = "upload"
     Owner       = "tburdett"

--- a/terraform/modules/database/database.tf
+++ b/terraform/modules/database/database.tf
@@ -2,10 +2,10 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   count              = "${var.db_instance_count}"
   identifier         = "upload-cluster-${var.deployment_stage}-${count.index}"
   cluster_identifier = "${aws_rds_cluster.upload.id}"
-  instance_class     = "db.r4.large"
+  instance_class     = "db.t3.medium"
   publicly_accessible = "true"
   engine                  = "aurora-postgresql"
-  engine_version          = "9.6.12"
+  engine_version          = "10.11"
   auto_minor_version_upgrade = "true"
   performance_insights_enabled = "true"
   preferred_maintenance_window = "${var.preferred_maintenance_window}"
@@ -15,7 +15,7 @@ resource "aws_rds_cluster" "upload" {
   apply_immediately       = "false"
   cluster_identifier      = "upload-${var.deployment_stage}"
   engine                  = "aurora-postgresql"
-  engine_version          = "9.6.12"
+  engine_version          = "10.11"
   availability_zones      = ["us-east-1a", "us-east-1c", "us-east-1d"]
   database_name           = "upload_${var.deployment_stage}"
   master_username         = "${var.db_username}"
@@ -28,5 +28,11 @@ resource "aws_rds_cluster" "upload" {
   skip_final_snapshot     = "true"
   vpc_security_group_ids  = ["${aws_security_group.rds-postgres.id}"]
   db_subnet_group_name    = "${aws_db_subnet_group.db_subnet_group.name}"
-  db_cluster_parameter_group_name = "default.aurora-postgresql9.6"
+  db_cluster_parameter_group_name = "default.aurora-postgresql10"
+  tags          = {
+    Name        = "upload"
+    Owner       = "tburdett"
+    Project     = "hca"
+    Service     = "ait"
+  }
 }

--- a/terraform/modules/database/pgbouncer.tf
+++ b/terraform/modules/database/pgbouncer.tf
@@ -140,6 +140,12 @@ EOF
 
 resource "aws_ecs_cluster" "pgbouncer" {
   name = "upload-service-pgbouncer-${var.deployment_stage}"
+  tags          = {
+    Name        = "upload-service"
+    Owner       = "tburdett"
+    Project     = "hca"
+    Service     = "ait"
+  }
 }
 
 resource "aws_ecs_service" "pgbouncer" {
@@ -183,6 +189,12 @@ resource "aws_lb" "main" {
   subnets         = ["${var.lb_subnet_ids}"]
   load_balancer_type = "network"
   internal           = false
+  tags          = {
+    Name        = "upload-pgbouncer"
+    Owner       = "tburdett"
+    Project     = "hca"
+    Service     = "ait"
+  }
 }
 
 resource "aws_lb_target_group" "pgbouncer" {

--- a/terraform/modules/database/variables.tf
+++ b/terraform/modules/database/variables.tf
@@ -30,3 +30,18 @@ variable "db_instance_count" {
 variable "preferred_maintenance_window" {
   type = "string"
 }
+
+// AWS RDS Cluster instance
+
+variable "aws_rds_cluster_instance_class" {
+  type = "string"
+}
+
+variable "aws_rds_cluster_instance_engine_version" {
+  type = "string"
+}
+
+variable "aws_rds_db_cluster_parameter_group_name" {
+  type = "string"
+}
+

--- a/terraform/modules/upload-service/api_lambda.tf
+++ b/terraform/modules/upload-service/api_lambda.tf
@@ -120,6 +120,6 @@ resource "aws_lambda_function" "upload_api_lambda" {
     Owner       = "tburdett"
     Project     = "hca"
     Service     = "ait"
-    environment = "dev"
+    environment = "${var.deployment_stage}"
   }
 }

--- a/terraform/modules/upload-service/api_lambda.tf
+++ b/terraform/modules/upload-service/api_lambda.tf
@@ -117,5 +117,9 @@ resource "aws_lambda_function" "upload_api_lambda" {
   }
   tags {
     aws-chalice = "version=1.1.1:stage=${var.deployment_stage}:app=upload-api"
+    Owner       = "tburdett"
+    Project     = "hca"
+    Service     = "ait"
+    environment = "dev"
   }
 }

--- a/terraform/modules/upload-service/area_deletion_lambda.tf
+++ b/terraform/modules/upload-service/area_deletion_lambda.tf
@@ -135,7 +135,7 @@ resource "aws_lambda_function" "area_deletion_lambda" {
     Owner       = "tburdett"
     Project     = "hca"
     Service     = "ait"
-    production  = "${var.deployment_stage}"
+    environment = "${var.deployment_stage}"
   }
   environment {
     variables = {

--- a/terraform/modules/upload-service/area_deletion_lambda.tf
+++ b/terraform/modules/upload-service/area_deletion_lambda.tf
@@ -135,7 +135,7 @@ resource "aws_lambda_function" "area_deletion_lambda" {
     Owner       = "tburdett"
     Project     = "hca"
     Service     = "ait"
-    production  = "dev"
+    production  = "${var.deployment_stage}"
   }
   environment {
     variables = {

--- a/terraform/modules/upload-service/area_deletion_lambda.tf
+++ b/terraform/modules/upload-service/area_deletion_lambda.tf
@@ -131,10 +131,17 @@ resource "aws_lambda_function" "area_deletion_lambda" {
   runtime          = "python3.6"
   memory_size      = 500
   timeout          = 900
-
+  tags             = {
+    Owner       = "tburdett"
+    Project     = "hca"
+    Service     = "ait"
+    production  = "dev"
+  }
   environment {
     variables = {
       DEPLOYMENT_STAGE = "${var.deployment_stage}"
     }
   }
+
+
 }

--- a/terraform/modules/upload-service/bucket.tf
+++ b/terraform/modules/upload-service/bucket.tf
@@ -4,9 +4,11 @@ resource "aws_s3_bucket" "upload_areas_bucket" {
   force_destroy = "false"
   acceleration_status = "Enabled"
   tags = {
+    Owner = "tburdett"
     Project = "hca"
+    Service = "ait"
+    environment = "${var.deployment_stage}"
   }
-
 }
 
 resource "aws_iam_policy" "upload_areas_submitter_access" {
@@ -90,6 +92,9 @@ resource "aws_s3_bucket" "lambda_deployments" {
   force_destroy = "false"
   acceleration_status = "Enabled"
   tags = {
+    Owner = "tburdett"
     Project = "hca"
+    Service = "ait"
+    environment = "${var.deployment_stage}"
   }
 }

--- a/terraform/modules/upload-service/bucket.tf
+++ b/terraform/modules/upload-service/bucket.tf
@@ -3,6 +3,10 @@ resource "aws_s3_bucket" "upload_areas_bucket" {
   acl = "private"
   force_destroy = "false"
   acceleration_status = "Enabled"
+  tags = {
+    Project = "hca"
+  }
+
 }
 
 resource "aws_iam_policy" "upload_areas_submitter_access" {
@@ -85,4 +89,7 @@ resource "aws_s3_bucket" "lambda_deployments" {
   acl = "private"
   force_destroy = "false"
   acceleration_status = "Enabled"
+  tags = {
+    Project = "hca"
+  }
 }

--- a/terraform/modules/upload-service/checksumming_lambda.tf
+++ b/terraform/modules/upload-service/checksumming_lambda.tf
@@ -117,7 +117,7 @@ resource "aws_lambda_function" "upload_checksum_lambda" {
     Owner       = "tburdett"
     Project     = "hca"
     Service     = "ait"
-    environment  = "dev"
+    environment  = "${var.deployment_stage}"
   }
   environment {
     variables = {

--- a/terraform/modules/upload-service/checksumming_lambda.tf
+++ b/terraform/modules/upload-service/checksumming_lambda.tf
@@ -113,7 +113,12 @@ resource "aws_lambda_function" "upload_checksum_lambda" {
   runtime          = "python3.6"
   memory_size      = 1500
   timeout          = 900
-
+  tags             = {
+    Owner       = "tburdett"
+    Project     = "hca"
+    Service     = "ait"
+    environment  = "dev"
+  }
   environment {
     variables = {
       DEPLOYMENT_STAGE = "${var.deployment_stage}",

--- a/terraform/modules/upload-service/health_check_lambda.tf
+++ b/terraform/modules/upload-service/health_check_lambda.tf
@@ -83,7 +83,12 @@ resource "aws_lambda_function" "upload_health_check_lambda" {
   runtime          = "python3.6"
   memory_size      = 128
   timeout          = 300
-
+  tags             = {
+    Owner       = "tburdett"
+    Project     = "hca"
+    Service     = "ait"
+    environment = "${var.deployment_stage}"
+  }
   environment {
     variables = {
       DEPLOYMENT_STAGE = "${var.deployment_stage}",

--- a/terraform/modules/upload-service/main.tf
+++ b/terraform/modules/upload-service/main.tf
@@ -21,4 +21,8 @@ module "upload-service-database" {
   lb_subnet_ids = "${data.aws_subnet_ids.upload_vpc.ids}"
   vpc_id = "${module.upload-vpc.vpc_id}"
   preferred_maintenance_window = "${var.preferred_maintenance_window}"
+  // AWS RDS Cluster Instance
+  aws_rds_cluster_instance_class="${var.aws_rds_cluster_instance_class}"
+  aws_rds_cluster_instance_engine_version="${var.aws_rds_cluster_instance_engine_version}"
+  aws_rds_db_cluster_parameter_group_name="${var.aws_rds_db_cluster_parameter_group_name}"
 }

--- a/terraform/modules/upload-service/validation_scheduler_lambda.tf
+++ b/terraform/modules/upload-service/validation_scheduler_lambda.tf
@@ -135,7 +135,7 @@ resource "aws_lambda_function" "validation_scheduler_lambda" {
     Owner       = "tburdett"
     Project     = "hca"
     Service     = "ait"
-    environment  = "dev"
+    environment  = "${var.deployment_stage}"
   }
   environment {
     variables = {

--- a/terraform/modules/upload-service/validation_scheduler_lambda.tf
+++ b/terraform/modules/upload-service/validation_scheduler_lambda.tf
@@ -131,7 +131,12 @@ resource "aws_lambda_function" "validation_scheduler_lambda" {
   runtime          = "python3.6"
   memory_size      = 500
   timeout          = 900
-
+  tags             = {
+    Owner       = "tburdett"
+    Project     = "hca"
+    Service     = "ait"
+    environment  = "dev"
+  }
   environment {
     variables = {
       DEPLOYMENT_STAGE = "${var.deployment_stage}",

--- a/terraform/modules/upload-service/variables.tf
+++ b/terraform/modules/upload-service/variables.tf
@@ -118,3 +118,18 @@ data "aws_region" "current" {}
 data "aws_subnet_ids" "upload_vpc" {
   vpc_id = "${module.upload-vpc.vpc_id}"
 }
+
+// AWS RDS Cluster instance
+
+variable "aws_rds_cluster_instance_class" {
+  type = "string"
+}
+
+variable "aws_rds_cluster_instance_engine_version" {
+  type = "string"
+}
+
+variable "aws_rds_db_cluster_parameter_group_name" {
+  type = "string"
+}
+


### PR DESCRIPTION
Resolving the following conflicts:

 ```
  ~ module.upload-service.aws_lambda_function.area_deletion_lambda
      tags.%:                            "4" => "0"
      tags.Owner:                        "tburdett" => ""
      tags.Project:                      "hca" => ""
      tags.Service:                      "ait" => ""
      tags.production:                   "dev" => ""
  ~ module.upload-service.aws_lambda_function.upload_api_lambda
      tags.%:                            "5" => "1"
      tags.Owner:                        "tburdett" => ""
      tags.Project:                      "hca" => ""
      tags.Service:                      "ait" => ""
      tags.environment:                  "dev" => ""
  ~ module.upload-service.aws_lambda_function.upload_checksum_lambda
      tags.%:                            "4" => "0"
      tags.Owner:                        "tburdett" => ""
      tags.Project:                      "hca" => ""
      tags.Service:                      "ait" => ""
      tags.environment:                  "dev" => ""
  ~ module.upload-service.aws_lambda_function.validation_scheduler_lambda
      tags.%:                            "4" => "0"
      tags.Owner:                        "tburdett" => ""
      tags.Project:                      "hca" => ""
      tags.Service:                      "ait" => ""
      tags.environment:                  "dev" => ""
  ~ module.upload-service.aws_s3_bucket.lambda_deployments
      tags.%:                            "1" => "0"
      tags.Project:                      "hca" => ""
  ~ module.upload-service.aws_s3_bucket.upload_areas_bucket
      tags.%:                            "1" => "0"
      tags.Project:                      "hca" => ""
-/+ module.upload-service.aws_secretsmanager_secret_version.secrets (new resource required)
      id:                                "dcp/upload/dev/secrets|35AEAEA6-4622-4A9C-A1D6-65948EC74BA6" => <computed> (forces new resource)
      arn:                               "arn:aws:secretsmanager:us-east-1:871979166454:secret:dcp/upload/dev/secrets-JbuXao" => <computed>
      secret_id:                         "dcp/upload/dev/secrets" => "dcp/upload/dev/secrets"
      secret_string:                     <sensitive> => <sensitive> (forces new resource)
      version_id:                        "35AEAEA6-4622-4A9C-A1D6-65948EC74BA6" => <computed>
      version_stages.#:                  "1" => <computed>
  ~ module.upload-service.module.upload-service-database.aws_ecs_cluster.pgbouncer
      tags.%:                            "4" => "0"
      tags.Name:                         "upload-service" => ""
      tags.Owner:                        "tburdett" => ""
      tags.Project:                      "hca" => ""
      tags.Service:                      "ait" => ""
  ~ module.upload-service.module.upload-service-database.aws_lb.main
      tags.%:                            "4" => "0"
      tags.Name:                         "upload-pgbouncer" => ""
      tags.Owner:                        "tburdett" => ""
      tags.Project:                      "hca" => ""
      tags.Service:                      "ait" => ""
  ~ module.upload-service.module.upload-service-database.aws_rds_cluster.upload
      db_cluster_parameter_group_name:   "default.aurora-postgresql10" => "default.aurora-postgresql9.6"
      engine_version:                    "10.11" => "9.6.12"
      tags.%:                            "4" => "0"
      tags.Name:                         "upload" => ""
      tags.Owner:                        "tburdett" => ""
      tags.Project:                      "hca" => ""
      tags.Service:                      "ait" => ""
-/+ module.upload-service.module.upload-service-database.aws_rds_cluster_instance.cluster_instances (new resource required)
      id:                                "upload-cluster-dev-0" => <computed> (forces new resource)
      apply_immediately:                 "" => <computed>
      arn:                               "arn:aws:rds:us-east-1:871979166454:db:upload-cluster-dev-0" => <computed>
      auto_minor_version_upgrade:        "true" => "true"
      availability_zone:                 "us-east-1a" => <computed>
      ca_cert_identifier:                "rds-ca-2019" => <computed>
      cluster_identifier:                "upload-dev" => "upload-dev"
      copy_tags_to_snapshot:             "false" => "false"
      db_parameter_group_name:           "default.aurora-postgresql10" => <computed>
      db_subnet_group_name:              "upload_db_subnet_group_dev" => <computed>
      dbi_resource_id:                   "db-YKQBXHOLAHNVRNC3T5ZW4XLOOQ" => <computed>
      endpoint:                          "upload-cluster-dev-0.cdbjygwfgkap.us-east-1.rds.amazonaws.com" => <computed>
      engine:                            "aurora-postgresql" => "aurora-postgresql"
      engine_version:                    "10.11" => "9.6.12" (forces new resource)
      identifier:                        "upload-cluster-dev-0" => "upload-cluster-dev-0"
      identifier_prefix:                 "" => <computed>
      instance_class:                    "db.t3.medium" => "db.r4.large"
      kms_key_id:                        "arn:aws:kms:us-east-1:871979166454:key/a5d6dbe1-5892-41ff-9ebf-c5cce8def489" => <computed>
      monitoring_interval:               "0" => "0"
      monitoring_role_arn:               "" => <computed>
      performance_insights_enabled:      "true" => "true"
      performance_insights_kms_key_id:   "arn:aws:kms:us-east-1:871979166454:key/a5d6dbe1-5892-41ff-9ebf-c5cce8def489" => <computed>
      port:                              "5432" => <computed>
      preferred_backup_window:           "07:27-07:57" => <computed>
      preferred_maintenance_window:      "sat:09:08-sat:09:38" => "sat:09:08-sat:09:38"
      promotion_tier:                    "0" => "0"
      publicly_accessible:               "true" => "true"
      storage_encrypted:                 "true" => <computed>
      writer:                            "true" => <computed>
```