### PR TITLE
Increase timeout to accomodate 220GB file validation

### DIFF
--- a/upload/docker_images/validator/validator_harness.py
+++ b/upload/docker_images/validator/validator_harness.py
@@ -20,7 +20,7 @@ logger = get_logger(f"CHECKSUMMER [{os.environ.get('AWS_BATCH_JOB_ID')}]")
 
 class ValidatorHarness:
     DEFAULT_STAGING_AREA = "/data"
-    TIMEOUT = 3600  # kill job after 1 hour
+    TIMEOUT = 14400  # kill job after 4 hours
 
     def __init__(self, path_to_validator, s3_urls_of_files_to_be_validated, staging_folder=None):
         self.path_to_validator = path_to_validator


### PR DESCRIPTION
ebi-ait/hca-ebi-dev-team#309


Based from past fastq validation runs

|File size | Download Time | Fastq validation Time| Total Time|
| --------|----------------- |---------------------|-----------|
| 39 GB   |   11 min                | 32 min                       | 43 min     |
| 46 GB   |   18 min               | 39 min                       | 57 min      |

The largest file size in the submission is 220GB. which would take approximately ~3hrs .

I've increased the timeout limit to **4hours** to handle 200GB~ fastq files.

It would be nice to record these stats and do performance assessment of the fastq validation in the upload service.
