### PR TITLE
Tagged Validation and Checksumming compute environments

### DIFF
--- a/terraform/modules/upload-service/checksumming_batch.tf
+++ b/terraform/modules/upload-service/checksumming_batch.tf
@@ -1,5 +1,7 @@
 data "external" "checksum_desired_vcpus" {
-  program = ["python", "${path.module}/fetch_batch_vcpus.py"]
+  program = [
+    "python",
+    "${path.module}/fetch_batch_vcpus.py"]
 
   query = {
     compute_environment_name = "dcp-upload-csum-cluster-${var.deployment_stage}"
@@ -31,11 +33,21 @@ resource "aws_batch_compute_environment" "csum_compute_env" {
     ]
     ec2_key_pair = "${var.csum_cluster_ec2_key_pair}"
     instance_role = "${aws_iam_instance_profile.ecsInstanceRole.arn}"
-    // Do not appear to work.  They do not stick.
-    // tags {
-    //   Name = "dcp-upload-csum-${var.deployment_stage}"
-    // }
+
+    tags = {
+      Name = "dcp-upload-csum-${var.deployment_stage}"
+      Owner = "tburdett"
+      Project = "hca"
+      Service = "ait"
+      environment = "${var.deployment_stage}"
+    }
+
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
   depends_on = [
     "aws_iam_role_policy_attachment.AWSBatchServiceRole"
   ]

--- a/terraform/modules/upload-service/validation.tf
+++ b/terraform/modules/upload-service/validation.tf
@@ -1,5 +1,7 @@
 data "external" "validation_desired_vcpus" {
-  program = ["python", "${path.module}/fetch_batch_vcpus.py"]
+  program = [
+    "python",
+    "${path.module}/fetch_batch_vcpus.py"]
 
   query = {
     compute_environment_name = "dcp-upload-validation-cluster-${var.deployment_stage}"
@@ -32,11 +34,21 @@ resource "aws_batch_compute_environment" "validation_compute_env" {
     ]
     ec2_key_pair = "${var.validation_cluster_ec2_key_pair}"
     instance_role = "${aws_iam_instance_profile.ecsInstanceRole.arn}"
-    // Do not appear to work.  They do not stick.
-    // tags {
-    //   Name = "dcp-upload-validation-${var.deployment_stage}"
-    // }
+
+    tags = {
+      Name = "dcp-upload-validation-${var.deployment_stage}"
+      Owner = "tburdett"
+      Project = "hca"
+      Service = "ait"
+      environment = "${var.deployment_stage}"
+    }
+
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
   depends_on = [
     "aws_iam_role_policy_attachment.AWSBatchServiceRole"
   ]


### PR DESCRIPTION
The config changes were applied in dev and integration test was still passing after.

Applied the workaround described here to be able to delete the compute environments to apply the new tags to it. https://github.com/terraform-providers/terraform-provider-aws/issues/2044#issuecomment-548368564

Steps:
1. Add lifecycle hook to the tf config to create a new one first before deleting and avoid encountering the delete dependency with the job queue
```
lifecycle {
    create_before_destroy = true
  }
```
2. Add a suffix `-2` to the `compute_environment_name` to be able to create a new compute environment not conflicting with existing one to be deleted

```
compute_environment_name = "dcp-upload-validation-cluster-${var.deployment_stage}-2"
```
3. Apply the changes (Follow SOP here: https://github.com/HumanCellAtlas/ingest-central/wiki/Upload-Service)
```
make apply
```

4. Update the config to revert to original name

```
compute_environment_name = "dcp-upload-validation-cluster-${var.deployment_stage}"
```

5. Apply the changes again
```
make apply
```

According to the [AWS documentation](https://aws.amazon.com/about-aws/whats-new/2017/10/tag-your-aws-batch-spot-managed-compute-environments/#:~:text=Now%20you%20can%20provide%20user,purpose%2C%20owner%2C%20or%20environment.) batch instances should be auto tagged.

Related to ticket: ebi-ait/hca-ebi-dev-team#295