### PR TITLE
Make tagging consistent with Ingest Service tags

### DIFF
--- a/terraform/envs/_template/variables.tf
+++ b/terraform/envs/_template/variables.tf
@@ -109,3 +109,7 @@ variable "dcp_auth0_audience" {
 variable "gcp_service_acct_creds" {
   type = "string"
 }
+
+variable "default_tags" {
+    type = "map"
+}

--- a/terraform/envs/dev/main.tf
+++ b/terraform/envs/dev/main.tf
@@ -71,6 +71,8 @@ module "upload-service" {
   aws_rds_cluster_instance_class="${var.aws_rds_cluster_instance_class}"
   aws_rds_cluster_instance_engine_version="${var.aws_rds_cluster_instance_engine_version}"
   aws_rds_db_cluster_parameter_group_name="${var.aws_rds_db_cluster_parameter_group_name}"
+
+  default_tags = "${var.default_tags}"
 }
 
 output "upload_csum_lambda_role_arn" {

--- a/terraform/envs/dev/variables.tf
+++ b/terraform/envs/dev/variables.tf
@@ -124,3 +124,6 @@ variable "aws_rds_db_cluster_parameter_group_name" {
   type = "string"
 }
 
+variable "default_tags" {
+    type = "map"
+}

--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -71,6 +71,8 @@ module "upload-service" {
   aws_rds_cluster_instance_class="${var.aws_rds_cluster_instance_class}"
   aws_rds_cluster_instance_engine_version="${var.aws_rds_cluster_instance_engine_version}"
   aws_rds_db_cluster_parameter_group_name="${var.aws_rds_db_cluster_parameter_group_name}"
+
+  default_tags = "${var.default_tags}"
 }
 
 output "upload_csum_lambda_role_arn" {

--- a/terraform/envs/staging/main.tf
+++ b/terraform/envs/staging/main.tf
@@ -71,6 +71,8 @@ module "upload-service" {
   aws_rds_cluster_instance_class="${var.aws_rds_cluster_instance_class}"
   aws_rds_cluster_instance_engine_version="${var.aws_rds_cluster_instance_engine_version}"
   aws_rds_db_cluster_parameter_group_name="${var.aws_rds_db_cluster_parameter_group_name}"
+
+  default_tags = "${var.default_tags}"
 }
 
 output "upload_csum_lambda_role_arn" {

--- a/terraform/modules/database/database.tf
+++ b/terraform/modules/database/database.tf
@@ -9,6 +9,13 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   auto_minor_version_upgrade = "true"
   performance_insights_enabled = "true"
   preferred_maintenance_window = "${var.preferred_maintenance_window}"
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name","upload",
+      "Env","${var.deployment_stage}"
+    )
+  )}"
 }
 
 resource "aws_rds_cluster" "upload" {
@@ -29,10 +36,11 @@ resource "aws_rds_cluster" "upload" {
   vpc_security_group_ids  = ["${aws_security_group.rds-postgres.id}"]
   db_subnet_group_name    = "${aws_db_subnet_group.db_subnet_group.name}"
   db_cluster_parameter_group_name = "${var.aws_rds_db_cluster_parameter_group_name}"
-  tags          = {
-    Name        = "upload"
-    Owner       = "tburdett"
-    Project     = "hca"
-    Service     = "ait"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name","upload",
+      "Env","${var.deployment_stage}"
+    )
+  )}"
 }

--- a/terraform/modules/database/pgbouncer.tf
+++ b/terraform/modules/database/pgbouncer.tf
@@ -140,12 +140,13 @@ EOF
 
 resource "aws_ecs_cluster" "pgbouncer" {
   name = "upload-service-pgbouncer-${var.deployment_stage}"
-  tags          = {
-    Name        = "upload-service"
-    Owner       = "tburdett"
-    Project     = "hca"
-    Service     = "ait"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name","upload",
+      "Env","${var.deployment_stage}"
+    )
+  )}"
 }
 
 resource "aws_ecs_service" "pgbouncer" {
@@ -189,12 +190,13 @@ resource "aws_lb" "main" {
   subnets         = ["${var.lb_subnet_ids}"]
   load_balancer_type = "network"
   internal           = false
-  tags          = {
-    Name        = "upload-pgbouncer"
-    Owner       = "tburdett"
-    Project     = "hca"
-    Service     = "ait"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name","upload-pgbouncer",
+      "Env","${var.deployment_stage}"
+    )
+  )}"
 }
 
 resource "aws_lb_target_group" "pgbouncer" {

--- a/terraform/modules/database/secrets.tf
+++ b/terraform/modules/database/secrets.tf
@@ -1,11 +1,13 @@
 
 resource "aws_secretsmanager_secret" "database-secrets" {
   name = "dcp/upload/${var.deployment_stage}/database"
-  tags          = {
-    Owner       = "tburdett"
-    Project     = "hca"
-    Service     = "ait"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name","DCP Upload ${var.deployment_stage} DB Subnet Group",
+      "Env","${var.deployment_stage}"
+    )
+  )}"
 }
 
 resource "aws_secretsmanager_secret_version" "database-secrets" {

--- a/terraform/modules/database/subnet.tf
+++ b/terraform/modules/database/subnet.tf
@@ -1,8 +1,11 @@
 resource "aws_db_subnet_group" "db_subnet_group" {
   name       = "upload_db_subnet_group_${var.deployment_stage}"
   subnet_ids = ["${var.lb_subnet_ids}"]
-
-  tags {
-    Name = "DCP Upload ${var.deployment_stage} DB Subnet Group"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name","DCP Upload ${var.deployment_stage} DB Subnet Group",
+      "Env","${var.deployment_stage}"
+    )
+  )}"
 }

--- a/terraform/modules/database/variables.tf
+++ b/terraform/modules/database/variables.tf
@@ -45,3 +45,6 @@ variable "aws_rds_db_cluster_parameter_group_name" {
   type = "string"
 }
 
+variable "default_tags" {
+  type = "map"
+}

--- a/terraform/modules/upload-service/api_lambda.tf
+++ b/terraform/modules/upload-service/api_lambda.tf
@@ -115,11 +115,11 @@ resource "aws_lambda_function" "upload_api_lambda" {
       API_HOST = "${var.upload_api_fqdn}"
     }
   }
-  tags {
-    aws-chalice = "version=1.1.1:stage=${var.deployment_stage}:app=upload-api"
-    Owner       = "tburdett"
-    Project     = "hca"
-    Service     = "ait"
-    environment = "${var.deployment_stage}"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name", "upload",
+      "Env", "${var.deployment_stage}",
+      "aws-chalice", "version=1.1.1:stage=${var.deployment_stage}:app=upload-api"
+    ))}"
 }

--- a/terraform/modules/upload-service/area_deletion_lambda.tf
+++ b/terraform/modules/upload-service/area_deletion_lambda.tf
@@ -131,12 +131,13 @@ resource "aws_lambda_function" "area_deletion_lambda" {
   runtime          = "python3.6"
   memory_size      = 500
   timeout          = 900
-  tags             = {
-    Owner       = "tburdett"
-    Project     = "hca"
-    Service     = "ait"
-    environment = "${var.deployment_stage}"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name","upload",
+      "Env","${var.deployment_stage}"
+    )
+  )}"
   environment {
     variables = {
       DEPLOYMENT_STAGE = "${var.deployment_stage}"

--- a/terraform/modules/upload-service/bucket.tf
+++ b/terraform/modules/upload-service/bucket.tf
@@ -3,12 +3,13 @@ resource "aws_s3_bucket" "upload_areas_bucket" {
   acl = "private"
   force_destroy = "false"
   acceleration_status = "Enabled"
-  tags = {
-    Owner = "tburdett"
-    Project = "hca"
-    Service = "ait"
-    environment = "${var.deployment_stage}"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name","upload",
+      "Env","${var.deployment_stage}"
+    )
+  )}"
 }
 
 resource "aws_iam_policy" "upload_areas_submitter_access" {
@@ -91,10 +92,11 @@ resource "aws_s3_bucket" "lambda_deployments" {
   acl = "private"
   force_destroy = "false"
   acceleration_status = "Enabled"
-  tags = {
-    Owner = "tburdett"
-    Project = "hca"
-    Service = "ait"
-    environment = "${var.deployment_stage}"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name","upload",
+      "Env","${var.deployment_stage}"
+    )
+  )}"
 }

--- a/terraform/modules/upload-service/checksumming_batch.tf
+++ b/terraform/modules/upload-service/checksumming_batch.tf
@@ -34,14 +34,13 @@ resource "aws_batch_compute_environment" "csum_compute_env" {
     ec2_key_pair = "${var.csum_cluster_ec2_key_pair}"
     instance_role = "${aws_iam_instance_profile.ecsInstanceRole.arn}"
 
-    tags = {
-      Name = "dcp-upload-csum-${var.deployment_stage}"
-      Owner = "tburdett"
-      Project = "hca"
-      Service = "ait"
-      environment = "${var.deployment_stage}"
-    }
-
+    tags = "${merge(
+      var.default_tags,
+      map(
+        "Name","dcp-upload-csum-${var.deployment_stage}",
+        "Env","${var.deployment_stage}"
+      )
+    )}"
   }
 
   lifecycle {

--- a/terraform/modules/upload-service/checksumming_lambda.tf
+++ b/terraform/modules/upload-service/checksumming_lambda.tf
@@ -113,12 +113,13 @@ resource "aws_lambda_function" "upload_checksum_lambda" {
   runtime          = "python3.6"
   memory_size      = 1500
   timeout          = 900
-  tags             = {
-    Owner       = "tburdett"
-    Project     = "hca"
-    Service     = "ait"
-    environment  = "${var.deployment_stage}"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Env","${var.deployment_stage}"
+    )
+  )}"
+
   environment {
     variables = {
       DEPLOYMENT_STAGE = "${var.deployment_stage}",

--- a/terraform/modules/upload-service/main.tf
+++ b/terraform/modules/upload-service/main.tf
@@ -9,6 +9,7 @@ module "upload-vpc" {
   component_name = "upload"
   deployment_stage = "${var.deployment_stage}"
   vpc_cidr_block = "${var.vpc_cidr_block}"
+  default_tags = "${var.default_tags}"
 }
 
 module "upload-service-database" {
@@ -25,4 +26,6 @@ module "upload-service-database" {
   aws_rds_cluster_instance_class="${var.aws_rds_cluster_instance_class}"
   aws_rds_cluster_instance_engine_version="${var.aws_rds_cluster_instance_engine_version}"
   aws_rds_db_cluster_parameter_group_name="${var.aws_rds_db_cluster_parameter_group_name}"
+
+  default_tags = "${var.default_tags}"
 }

--- a/terraform/modules/upload-service/validation.tf
+++ b/terraform/modules/upload-service/validation.tf
@@ -35,13 +35,13 @@ resource "aws_batch_compute_environment" "validation_compute_env" {
     ec2_key_pair = "${var.validation_cluster_ec2_key_pair}"
     instance_role = "${aws_iam_instance_profile.ecsInstanceRole.arn}"
 
-    tags = {
-      Name = "dcp-upload-validation-${var.deployment_stage}"
-      Owner = "tburdett"
-      Project = "hca"
-      Service = "ait"
-      environment = "${var.deployment_stage}"
-    }
+    tags = "${merge(
+      var.default_tags,
+      map(
+        "Name","dcp-upload-validation-${var.deployment_stage}",
+        "Env", "${var.deployment_stage}"
+      )
+    )}"
 
   }
 

--- a/terraform/modules/upload-service/validation_scheduler_lambda.tf
+++ b/terraform/modules/upload-service/validation_scheduler_lambda.tf
@@ -131,12 +131,12 @@ resource "aws_lambda_function" "validation_scheduler_lambda" {
   runtime          = "python3.6"
   memory_size      = 500
   timeout          = 900
-  tags             = {
-    Owner       = "tburdett"
-    Project     = "hca"
-    Service     = "ait"
-    environment  = "${var.deployment_stage}"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Env","${var.deployment_stage}"
+    )
+  )}"
   environment {
     variables = {
       DEPLOYMENT_STAGE = "${var.deployment_stage}",

--- a/terraform/modules/upload-service/variables.tf
+++ b/terraform/modules/upload-service/variables.tf
@@ -133,3 +133,6 @@ variable "aws_rds_db_cluster_parameter_group_name" {
   type = "string"
 }
 
+variable "default_tags" {
+    type = "map"
+}

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -23,3 +23,6 @@ output "vpc_default_security_group_id" {
   value = "${aws_vpc.vpc.default_security_group_id}"
 }
 
+variable "default_tags" {
+    type = "map"
+}

--- a/terraform/modules/vpc/vpc.tf
+++ b/terraform/modules/vpc/vpc.tf
@@ -35,22 +35,32 @@ resource "aws_vpc" "vpc" {
   enable_dns_support = true
   enable_dns_hostnames = true
 
-  tags = {
-    Name = "${var.component_name}-${var.deployment_stage}"
-    component = "${var.component_name}"
-    deployment_stage = "${var.deployment_stage}"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name","${var.component_name}-${var.deployment_stage}",
+      "Env","${var.deployment_stage}",
+      "component","${var.component_name}",
+      "deployment_stage","${var.deployment_stage}"
+    )
+  )}"
+
 }
 
 resource "aws_vpc_dhcp_options" "opts" {
   domain_name          = "ec2.internal"
   domain_name_servers  = ["AmazonProvidedDNS"]
 
-  tags = {
-    Name = "${var.component_name}-${var.deployment_stage}"
-    component = "${var.component_name}"
-    deployment_stage = "${var.deployment_stage}"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name","${var.component_name}-${var.deployment_stage}",
+      "Env","${var.deployment_stage}",
+      "component","${var.component_name}",
+      "deployment_stage","${var.deployment_stage}"
+    )
+  )}"
+
 }
 
 resource "aws_vpc_dhcp_options_association" "a" {
@@ -61,11 +71,16 @@ resource "aws_vpc_dhcp_options_association" "a" {
 resource "aws_internet_gateway" "igw" {
   vpc_id = "${aws_vpc.vpc.id}"
 
-  tags = {
-    Name = "${var.component_name}-${var.deployment_stage}"
-    component = "${var.component_name}"
-    deployment_stage = "${var.deployment_stage}"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name","${var.component_name}-${var.deployment_stage}",
+      "Env","${var.deployment_stage}",
+      "component","${var.component_name}",
+      "deployment_stage","${var.deployment_stage}"
+    )
+  )}"
+
 }
 
 resource "aws_route_table" "rt" {
@@ -76,11 +91,15 @@ resource "aws_route_table" "rt" {
     gateway_id = "${aws_internet_gateway.igw.id}"
   }
 
-  tags = {
-    Name = "${var.component_name}-${var.deployment_stage}"
-    component = "${var.component_name}"
-    deployment_stage = "${var.deployment_stage}"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name","${var.component_name}-${var.deployment_stage}",
+      "Env","${var.deployment_stage}",
+      "component","${var.component_name}",
+      "deployment_stage","${var.deployment_stage}"
+    )
+  )}"
 }
 
 resource "aws_main_route_table_association" "a" {

--- a/terraform/modules/vpc/vpc.tf
+++ b/terraform/modules/vpc/vpc.tf
@@ -96,11 +96,15 @@ resource "aws_subnet" "sn" {
   vpc_id            = "${aws_vpc.vpc.id}"
   map_public_ip_on_launch = true
 
-  tags = {
-    Name = "${var.component_name}-${var.deployment_stage}-${local.az_names[count.index]}"
-    component = "${var.component_name}"
-    deployment_stage = "${var.deployment_stage}"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name","${var.component_name}-${var.deployment_stage}-${local.az_names[count.index]}",
+      "Env","${var.deployment_stage}",
+      "component","${var.component_name}",
+      "deployment_stage","${var.deployment_stage}"
+    )
+  )}"
 }
 
 resource "aws_route_table_association" "a" {
@@ -127,9 +131,13 @@ resource "aws_default_security_group" "sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = {
-    Name = "${var.component_name}-${var.deployment_stage}-default"
-    component = "${var.component_name}"
-    deployment_stage = "${var.deployment_stage}"
-  }
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name","${var.component_name}-${var.deployment_stage}-default",
+      "Env","${var.deployment_stage}",
+      "component","${var.component_name}",
+      "deployment_stage","${var.deployment_stage}"
+    )
+  )}"
 }


### PR DESCRIPTION
Fixed resources with non compliant tags

I applied the tags and ran integration tests in dev -> staging -> prod (sequentially) last Friday evening. The Ingest to upload test seems to be working fine. All non compliant resources I've identified as owned by upload service now have proper tags.

ebi-ait/hca-ebi-dev-team#295
